### PR TITLE
feat: integrate code generation, quality scan, and runtime analysis logging to audit service

### DIFF
--- a/src/main/java/org/springforge/cicdassistant/audit/AuditEventType.kt
+++ b/src/main/java/org/springforge/cicdassistant/audit/AuditEventType.kt
@@ -3,5 +3,8 @@ package org.springforge.cicdassistant.audit
 enum class AuditEventType(val label: String) {
     GENERATION("Generation"),
     VALIDATION("Validation"),
-    EXPLAINABILITY("Explainability")
+    EXPLAINABILITY("Explainability"),
+    CODE_GENERATION("Code Gen"),
+    QUALITY_SCAN("Quality"),
+    RUNTIME_ANALYSIS("Runtime")
 }

--- a/src/main/java/org/springforge/cicdassistant/audit/AuditService.kt
+++ b/src/main/java/org/springforge/cicdassistant/audit/AuditService.kt
@@ -173,6 +173,99 @@ class AuditService(private val project: Project) : Disposable {
         )
     )
 
+    /**
+     * Code Generation module — logs a Gemini-powered code generation run.
+     * Field mapping:
+     *   filesCount   = total files from LLM
+     *   insightCount = files actually written
+     *   issuesWarn   = files skipped (already exist)
+     *   issuesError  = files that failed to write
+     *   sourceType   = "GEMINI"
+     *   artifacts    = "java_files"
+     */
+    fun logCodeGeneration(
+        filesGenerated: Int,
+        filesWritten: Int,
+        filesSkipped: Int,
+        fileErrors: Int,
+        durationMs: Long,
+        success: Boolean,
+        errorMsg: String? = null
+    ) = writeAsync(
+        AuditEvent(
+            eventType    = AuditEventType.CODE_GENERATION,
+            projectPath  = project.basePath,
+            sourceType   = "GEMINI",
+            artifacts    = "java_files",
+            filesCount   = filesGenerated,
+            insightCount = filesWritten,
+            issuesWarn   = filesSkipped,
+            issuesError  = fileErrors,
+            success      = success,
+            errorMsg     = errorMsg,
+            durationMs   = durationMs
+        )
+    )
+
+    /**
+     * Quality Scan module — logs an ML + Gemini quality analysis run.
+     * Field mapping:
+     *   filesCount   = total files analyzed
+     *   issuesWarn   = total violations found
+     *   issuesError  = critical violations
+     *   insightCount = AI fix suggestions generated
+     *   sourceType   = architecture pattern selected (e.g. "Layered")
+     *   artifacts    = "ml_analysis"
+     */
+    fun logQualityScan(
+        filesAnalyzed: Int,
+        totalViolations: Int,
+        criticalViolations: Int,
+        aiFixCount: Int,
+        architecture: String,
+        durationMs: Long,
+        success: Boolean,
+        errorMsg: String? = null
+    ) = writeAsync(
+        AuditEvent(
+            eventType    = AuditEventType.QUALITY_SCAN,
+            projectPath  = project.basePath,
+            sourceType   = architecture,
+            artifacts    = "ml_analysis",
+            filesCount   = filesAnalyzed,
+            issuesWarn   = totalViolations,
+            issuesError  = criticalViolations,
+            insightCount = aiFixCount,
+            success      = success,
+            errorMsg     = errorMsg,
+            durationMs   = durationMs
+        )
+    )
+
+    /**
+     * Runtime Analysis module — logs a stacktrace/error analysis run.
+     * Field mapping:
+     *   filesCount = 1 (one stacktrace submitted)
+     *   artifacts  = "stacktrace"
+     *   sourceType = "MANUAL_INPUT"
+     */
+    fun logRuntimeAnalysis(
+        durationMs: Long,
+        success: Boolean,
+        errorMsg: String? = null
+    ) = writeAsync(
+        AuditEvent(
+            eventType    = AuditEventType.RUNTIME_ANALYSIS,
+            projectPath  = project.basePath,
+            sourceType   = "MANUAL_INPUT",
+            artifacts    = "stacktrace",
+            filesCount   = 1,
+            success      = success,
+            errorMsg     = errorMsg,
+            durationMs   = durationMs
+        )
+    )
+
     // ── Read API (called from UI, runs on pooled thread via caller) ─────────────
 
     fun getRecentEvents(limit: Int = 50): List<AuditEvent> {

--- a/src/main/java/org/springforge/cicdassistant/audit/ui/AuditDashboardPanel.kt
+++ b/src/main/java/org/springforge/cicdassistant/audit/ui/AuditDashboardPanel.kt
@@ -29,9 +29,14 @@ class AuditDashboardPanel(private val project: Project) : JPanel(BorderLayout())
     private val service = AuditService.getInstance(project)
 
     // ── Summary cards ─────────────────────────────────────────────────────────
+    // Row 1: CI/CD Assistant
     private val genCard  = SummaryCard("GENERATIONS",   JBColor(Color(0x005CC5), Color(0x64B5F6)))
     private val valCard  = SummaryCard("VALIDATIONS",   JBColor(Color(0xD73A49), Color(0xEF5350)))
     private val explCard = SummaryCard("EXPLAINABILITY",JBColor(Color(0x6F42C1), Color(0xCE93D8)))
+    // Row 2: Other modules
+    private val codeGenCard = SummaryCard("CODE GEN",     JBColor(Color(0x0A7E07), Color(0x66BB6A)))
+    private val qualCard    = SummaryCard("QUALITY SCAN", JBColor(Color(0xE36209), Color(0xFFA726)))
+    private val runtimeCard = SummaryCard("RUNTIME",      JBColor(Color(0x005B99), Color(0x4FC3F7)))
 
     // ── Table ─────────────────────────────────────────────────────────────────
     private val tableModel = EventsTableModel()
@@ -68,10 +73,11 @@ class AuditDashboardPanel(private val project: Project) : JPanel(BorderLayout())
     // ══════════════════════════════════════════════════════════════════════════
 
     private fun setupUI() {
-        val summaryRow = JPanel(GridLayout(1, 3, 10, 0)).apply {
+        val summaryRow = JPanel(GridLayout(2, 3, 10, 8)).apply {
             isOpaque = false
             border   = JBUI.Borders.emptyBottom(12)
             add(genCard); add(valCard); add(explCard)
+            add(codeGenCard); add(qualCard); add(runtimeCard)
         }
 
         table.tableHeader.apply {
@@ -155,6 +161,9 @@ class AuditDashboardPanel(private val project: Project) : JPanel(BorderLayout())
         genCard.update(fmt(stats[AuditEventType.GENERATION]))
         valCard.update(fmt(stats[AuditEventType.VALIDATION]))
         explCard.update(fmt(stats[AuditEventType.EXPLAINABILITY]))
+        codeGenCard.update(fmt(stats[AuditEventType.CODE_GENERATION]))
+        qualCard.update(fmt(stats[AuditEventType.QUALITY_SCAN]))
+        runtimeCard.update(fmt(stats[AuditEventType.RUNTIME_ANALYSIS]))
     }
 
     private fun updateStatus() {
@@ -217,9 +226,12 @@ class AuditDashboardPanel(private val project: Project) : JPanel(BorderLayout())
                 ?.readBytes()?.let { "data:image/png;base64," + Base64.getEncoder().encodeToString(it) } ?: ""
         }.getOrDefault("")
 
-        val genEvents  = events.filter { it.eventType == AuditEventType.GENERATION }
-        val valEvents  = events.filter { it.eventType == AuditEventType.VALIDATION }
-        val explEvents = events.filter { it.eventType == AuditEventType.EXPLAINABILITY }
+        val genEvents     = events.filter { it.eventType == AuditEventType.GENERATION }
+        val valEvents     = events.filter { it.eventType == AuditEventType.VALIDATION }
+        val explEvents    = events.filter { it.eventType == AuditEventType.EXPLAINABILITY }
+        val codeGenEvents = events.filter { it.eventType == AuditEventType.CODE_GENERATION }
+        val qualEvents    = events.filter { it.eventType == AuditEventType.QUALITY_SCAN }
+        val runtimeEvents = events.filter { it.eventType == AuditEventType.RUNTIME_ANALYSIS }
         fun successPct(list: List<AuditEvent>) =
             if (list.isEmpty()) "—" else "${list.count { it.success } * 100 / list.size}%"
 
@@ -264,7 +276,7 @@ body { font-family: Arial, Helvetica, sans-serif; font-size: 9.5pt; color: #2429
             if (logoSrc.isNotEmpty())
                 appendLine("  <td style=\"width:48pt;padding-right:12pt;\"><img src=\"$logoSrc\" style=\"height:40pt;width:40pt;\"/></td>")
             appendLine("  <td>")
-            appendLine("    <div class=\"hdr-title\">CI/CD Audit Log Report</div>")
+            appendLine("    <div class=\"hdr-title\">SpringForge Audit Log Report</div>")
             appendLine("    <div class=\"hdr-sub\">Traceability &amp; Compliance Report &#8212; SpringForge Audit System</div>")
             appendLine("    <div class=\"hdr-meta\">Generated: ${timeFmt.format(java.time.Instant.now())} &#160;&#8226;&#160; ${events.size} event${if (events.size != 1) "s" else ""}</div>")
             appendLine("  </td>")
@@ -277,9 +289,12 @@ body { font-family: Arial, Helvetica, sans-serif; font-size: 9.5pt; color: #2429
             appendLine("<table class=\"stats-tbl\" cellspacing=\"0\">")
             appendLine("  <tr><th class=\"lbl\">Module</th><th>Total Events</th><th>Successes</th><th>Failures</th><th>Success Rate</th></tr>")
             listOf(
-                Triple("Generation",    genEvents,  "#005CC5"),
-                Triple("Validation",    valEvents,  "#D73A49"),
-                Triple("Explainability",explEvents, "#6F42C1")
+                Triple("CI/CD Generation",    genEvents,      "#005CC5"),
+                Triple("CI/CD Validation",    valEvents,      "#D73A49"),
+                Triple("CI/CD Explainability",explEvents,     "#6F42C1"),
+                Triple("Code Generation",     codeGenEvents,  "#0A7E07"),
+                Triple("Quality Scan",        qualEvents,     "#E36209"),
+                Triple("Runtime Analysis",    runtimeEvents,  "#005B99")
             ).forEach { (name, evts, hex) ->
                 val ok  = evts.count { it.success }
                 val fail= evts.size - ok
@@ -302,9 +317,12 @@ body { font-family: Arial, Helvetica, sans-serif; font-size: 9.5pt; color: #2429
             events.forEach { e ->
                 val timeStr = timeFmt.format(e.createdAt)
                 val typeHex = when(e.eventType) {
-                    AuditEventType.GENERATION    -> "#005CC5"
-                    AuditEventType.VALIDATION    -> "#D73A49"
-                    AuditEventType.EXPLAINABILITY-> "#6F42C1"
+                    AuditEventType.GENERATION     -> "#005CC5"
+                    AuditEventType.VALIDATION     -> "#D73A49"
+                    AuditEventType.EXPLAINABILITY -> "#6F42C1"
+                    AuditEventType.CODE_GENERATION -> "#0A7E07"
+                    AuditEventType.QUALITY_SCAN    -> "#E36209"
+                    AuditEventType.RUNTIME_ANALYSIS -> "#005B99"
                 }
                 val statusHtml = when {
                     !e.success -> "<span class=\"err\">&#10008; Error</span>"
@@ -312,6 +330,10 @@ body { font-family: Arial, Helvetica, sans-serif; font-size: 9.5pt; color: #2429
                         "<span class=\"err\">&#9888; ${e.issuesError} err</span>"
                     e.eventType == AuditEventType.VALIDATION && e.issuesWarn > 0 ->
                         "<span class=\"warn\">&#9888; ${e.issuesWarn} warn</span>"
+                    e.eventType == AuditEventType.QUALITY_SCAN && e.issuesError > 0 ->
+                        "<span class=\"err\">&#9888; ${e.issuesError} critical</span>"
+                    e.eventType == AuditEventType.QUALITY_SCAN && e.issuesWarn > 0 ->
+                        "<span class=\"warn\">&#9888; ${e.issuesWarn} violations</span>"
                     else -> "<span class=\"ok\">&#10004; OK</span>"
                 }
                 val detailHtml = when (e.eventType) {
@@ -319,13 +341,19 @@ body { font-family: Arial, Helvetica, sans-serif; font-size: 9.5pt; color: #2429
                         "${e.issuesError}E / ${e.issuesWarn}W / ${e.issuesInfo}I"
                     AuditEventType.EXPLAINABILITY ->
                         "${e.insightCount} insight${if (e.insightCount != 1) "s" else ""}"
+                    AuditEventType.CODE_GENERATION ->
+                        "${e.insightCount} written, ${e.issuesWarn} skipped"
+                    AuditEventType.QUALITY_SCAN ->
+                        "${e.filesCount} files, ${e.issuesWarn} violations (${e.insightCount} AI fixes)"
+                    AuditEventType.RUNTIME_ANALYSIS ->
+                        if (e.success) "Analysis complete" else e.errorMsg?.take(60) ?: "Failed"
                     else -> e.errorMsg?.take(60) ?: "—"
                 }
                 val dur = if (e.durationMs >= 1000) "%.1fs".format(e.durationMs / 1000.0)
                           else "${e.durationMs}ms"
                 appendLine("  <tr>")
                 appendLine("    <td style=\"white-space:nowrap;\">$timeStr</td>")
-                appendLine("    <td><span style=\"color:$typeHex;font-weight:bold;\">${e.eventType.label.uppercase().take(5)}</span></td>")
+                appendLine("    <td><span style=\"color:$typeHex;font-weight:bold;\">${e.eventType.label}</span></td>")
                 appendLine("    <td>${e.sourceType ?: "—"}</td>")
                 appendLine("    <td>${e.artifacts?.replace(",", ", ") ?: "—"}</td>")
                 appendLine("    <td style=\"text-align:center;\">${if (e.filesCount > 0) e.filesCount.toString() else "—"}</td>")
@@ -386,7 +414,7 @@ body { font-family: Arial, Helvetica, sans-serif; font-size: 9.5pt; color: #2429
             val e = rows[row]
             return when (col) {
                 0 -> timeFmt.format(e.createdAt)
-                1 -> e.eventType.label.uppercase().take(5)
+                1 -> e.eventType.label
                 2 -> e.sourceType ?: "—"
                 3 -> e.artifacts?.replace(",", ", ") ?: "—"
                 4 -> if (e.filesCount > 0) e.filesCount.toString() else "—"
@@ -413,6 +441,10 @@ body { font-family: Arial, Helvetica, sans-serif; font-size: 9.5pt; color: #2429
                     "⚠ ${event.issuesError} err"
                 event.eventType == AuditEventType.VALIDATION && event.issuesWarn > 0 ->
                     "⚠ ${event.issuesWarn} warn"
+                event.eventType == AuditEventType.QUALITY_SCAN && event.issuesError > 0 ->
+                    "⚠ ${event.issuesError} critical"
+                event.eventType == AuditEventType.QUALITY_SCAN && event.issuesWarn > 0 ->
+                    "⚠ ${event.issuesWarn} violations"
                 else -> "✅ OK"
             }
             val comp = super.getTableCellRendererComponent(table, label, isSelected, hasFocus, row, column)

--- a/src/main/java/org/springforge/codegeneration/actions/GenerateCodeAction.kt
+++ b/src/main/java/org/springforge/codegeneration/actions/GenerateCodeAction.kt
@@ -17,6 +17,7 @@ import org.springforge.codegeneration.parser.InputModel
 import org.springforge.codegeneration.parser.YamlParser
 import org.springforge.codegeneration.parser.YamlWriter
 import org.springforge.codegeneration.service.*
+import org.springforge.cicdassistant.audit.AuditService
 import org.springforge.codegeneration.validation.ValidationResult
 import org.springforge.codegeneration.validation.YamlValidator
 import java.io.File
@@ -71,6 +72,7 @@ class GenerateCodeAction : AnAction("Generate Code") {
         // ── 3. RUN FULL PIPELINE IN BACKGROUND ───────────────────────────
         object : Task.Backgroundable(project, "SpringForge: Generating Code...", true) {
             override fun run(indicator: ProgressIndicator) {
+                val startMs = System.currentTimeMillis()
                 try {
                     // 3a. Analyze project context
                     indicator.text = "Analyzing project structure..."
@@ -160,6 +162,14 @@ class GenerateCodeAction : AnAction("Generate Code") {
                         buildFile = depResult.buildFile
                     )
                     GenerationResultService.getInstance(project).publish(genResult)
+                    AuditService.getInstance(project).logCodeGeneration(
+                        filesGenerated = generatedFiles.size,
+                        filesWritten   = writeResult.written.size,
+                        filesSkipped   = writeResult.skipped.size,
+                        fileErrors     = writeResult.errors.size,
+                        durationMs     = System.currentTimeMillis() - startMs,
+                        success        = true
+                    )
 
                     // // Open the prompt file for reference
                     // ApplicationManager.getApplication().invokeLater {
@@ -172,11 +182,21 @@ class GenerateCodeAction : AnAction("Generate Code") {
                 } catch (ex: IllegalStateException) {
                     // API key missing
                     notify(project, ex.message ?: "Configuration error", NotificationType.ERROR)
+                    AuditService.getInstance(project).logCodeGeneration(
+                        filesGenerated = 0, filesWritten = 0, filesSkipped = 0, fileErrors = 0,
+                        durationMs = System.currentTimeMillis() - startMs,
+                        success    = false, errorMsg = ex.message
+                    )
                 } catch (ex: Exception) {
                     notify(
                         project,
                         "Code generation failed: ${ex.message}",
                         NotificationType.ERROR
+                    )
+                    AuditService.getInstance(project).logCodeGeneration(
+                        filesGenerated = 0, filesWritten = 0, filesSkipped = 0, fileErrors = 0,
+                        durationMs = System.currentTimeMillis() - startMs,
+                        success    = false, errorMsg = ex.message
                     )
                 }
             }

--- a/src/main/java/org/springforge/qualityassurance/actions/AnalyzeQualityAction.kt
+++ b/src/main/java/org/springforge/qualityassurance/actions/AnalyzeQualityAction.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindowManager
+import org.springforge.cicdassistant.audit.AuditService
 import org.springforge.qualityassurance.analysis.PsiFeatureExtractor
 import org.springforge.qualityassurance.model.CombinedAnalysisResult
 import org.springforge.qualityassurance.model.FileFeatureModel
@@ -41,6 +42,7 @@ class AnalyzeQualityAction : AnAction("Analyze Code Quality") {
             true
         ) {
             override fun run(indicator: ProgressIndicator) {
+                val startMs = System.currentTimeMillis()
                 try {
                     // ── STEP 1: Ensure tool window is visible FIRST ───────────
                     // This must happen on EDT before we try to get the panel
@@ -78,12 +80,14 @@ class AnalyzeQualityAction : AnAction("Analyze Code Quality") {
                     println("🟩 Initial report shown — overall: ${analysisResult.overall_display}, violations: ${analysisResult.total_violations}")
 
                     // ── STEP 5: Call Gemini for AI fix suggestions ────────────
+                    var aiFixCount = 0
                     if (analysisResult.anti_patterns.isNotEmpty()) {
                         indicator.text     = "🤖 Generating AI fix suggestions (Gemini)..."
                         indicator.fraction = 0.80
 
                         try {
                             val fixResult = MLServiceClient.generateProjectFixes(analysisResult)
+                            aiFixCount = fixResult.total_fixes
                             indicator.fraction = 0.95
 
                             // Update the panel on EDT with AI fixes
@@ -119,10 +123,26 @@ class AnalyzeQualityAction : AnAction("Analyze Code Quality") {
                         notifType
                     )
 
+                    AuditService.getInstance(project).logQualityScan(
+                        filesAnalyzed      = analysisResult.total_files_analyzed,
+                        totalViolations    = analysisResult.total_violations,
+                        criticalViolations = analysisResult.anti_patterns.count { it.severity == "CRITICAL" },
+                        aiFixCount         = aiFixCount,
+                        architecture       = architecture,
+                        durationMs         = System.currentTimeMillis() - startMs,
+                        success            = true
+                    )
+
                 } catch (ex: Exception) {
                     showError(
                         project,
                         "Analysis failed: ${ex.message}\n\nMake sure the ML Service is running on port 8081.\nStart it with: uvicorn app.main:app --port 8081 --reload"
+                    )
+                    AuditService.getInstance(project).logQualityScan(
+                        filesAnalyzed = 0, totalViolations = 0, criticalViolations = 0,
+                        aiFixCount = 0, architecture = architecture,
+                        durationMs = System.currentTimeMillis() - startMs,
+                        success = false, errorMsg = ex.message
                     )
                     ex.printStackTrace()
                 }

--- a/src/main/java/org/springforge/toolwindow/panels/RuntimeAnalysisPanel.kt
+++ b/src/main/java/org/springforge/toolwindow/panels/RuntimeAnalysisPanel.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.ui.JBColor
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
+import org.springforge.cicdassistant.audit.AuditService
 import org.springforge.runtimeanalysis.service.RuntimeAnalysisService
 import java.awt.*
 import java.awt.datatransfer.StringSelection
@@ -246,6 +247,7 @@ class RuntimeAnalysisPanel(private val project: Project) : JPanel() {
 
     private fun analyzeError(errorText: String) {
         showStatus("⏳  Analyzing…")
+        val startMs = System.currentTimeMillis()
 
         com.intellij.openapi.progress.ProgressManager.getInstance().run(
             object : com.intellij.openapi.progress.Task.Backgroundable(project, "SpringForge Analysis") {
@@ -256,11 +258,20 @@ class RuntimeAnalysisPanel(private val project: Project) : JPanel() {
                             onResult = { raw ->
                                 com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
                                     renderResult(raw)
+                                    AuditService.getInstance(project).logRuntimeAnalysis(
+                                        durationMs = System.currentTimeMillis() - startMs,
+                                        success    = true
+                                    )
                                 }
                             },
                             onError = { err ->
                                 com.intellij.openapi.application.ApplicationManager.getApplication().invokeLater {
                                     showStatus("❌  $err")
+                                    AuditService.getInstance(project).logRuntimeAnalysis(
+                                        durationMs = System.currentTimeMillis() - startMs,
+                                        success    = false,
+                                        errorMsg   = err
+                                    )
                                 }
                             }
                         )


### PR DESCRIPTION
## Description
Extends the existing audit logging system (previously only covering the CI/CD Assistant) to all four SpringForge modules: Code Generation, Quality Scan, and Runtime Analysis. All audit events from every module now appear in the unified Audit tab with auto-refresh, PDF export, and summary cards.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Code cleanup

## Related Issue(s)
<!-- Link related issues using #issue_number -->
Fixes #
Closes #
Related to #

## Changes Made
- Added 3 new enum values to `AuditEventType`: `CODE_GENERATION`, `QUALITY_SCAN`, `RUNTIME_ANALYSIS` — no DB schema change required as `event_type` is a VARCHAR column
- Added 3 new logging methods to `AuditService`: `logCodeGeneration()`, `logQualityScan()`, `logRuntimeAnalysis()` — all reuse existing `AuditEvent` fields via semantic remapping (e.g. `issuesWarn` = total violations for Quality Scan)
- Injected audit calls into `GenerateCodeAction` — logs files generated/written/skipped/errored and duration on both success and failure
- Injected audit calls into `AnalyzeQualityAction` — logs files analyzed, violation counts (total + critical), AI fix count, and architecture pattern; hoisted `aiFixCount` var to capture Gemini result even when the inner try-block is separate
- Injected audit calls into `RuntimeAnalysisPanel.analyzeError()` — logs duration and success/failure in the `onResult`/`onError` callbacks
- Expanded `AuditDashboardPanel`: summary card grid changed from `1×3` to `2×3` with 3 new colour-coded cards (green for Code Gen, orange for Quality, teal for Runtime); `updateCards()` feeds stats for all 6 event types; `EventsTableModel` type column no longer truncates labels; `StatusCellRenderer` handles Quality Scan violation counts; PDF export summary table extended to 6 module rows with appropriate colours and detail columns; report title updated to "SpringForge Audit Log Report"

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing completed

**Test Configuration:**
- Trigger Code Generation via the Code Gen tab → verify a `Code Gen` row appears in the Audit tab with correct file counts
- Run Quality Analysis → verify a `Quality` row appears with violation/file counts and architecture source
- Submit a stacktrace in the Runtime panel → verify a `Runtime` row appears with duration
- Force a failure (e.g. disconnect ML service before Quality Scan) → verify `success=false` event is logged with the error message
- Click "Export PDF" in the Audit tab → verify all 6 event types appear in the Summary table and Event Log with correct colours and detail text
- Click "Refresh" → verify all 6 card counts update correctly from the database

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate the changes -->

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
The PostgreSQL schema (`sf_audit_events`) is **unchanged** — the new event types are stored as new VARCHAR values in the existing `event_type` column. Existing audit records for CI/CD are fully preserved. The `AuditEvent` data model fields are reused via semantic remapping per module (documented in AuditService.kt KDoc comments). The audit dashboard auto-refresh (`onNewEvent` callback) works for all new modules automatically with no extra wiring needed.