### PR TITLE
Enhance project creation dialog with Java keyword validation and auto-sync package name

### DIFF
--- a/src/main/java/org/springforge/codegeneration/actions/CreateNewProjectAction.kt
+++ b/src/main/java/org/springforge/codegeneration/actions/CreateNewProjectAction.kt
@@ -88,7 +88,10 @@ class CreateNewProjectAction : AnAction("SpringForge: Create New Spring Boot Pro
                     enableAnnotationProcessing(targetDir)
 
                     indicator.text = "Applying Architecture Template..."
-                    TemplateGenerator.generate(targetDir, packageRoot, arch)
+                    // Use the package Spring Initializr actually placed the app class in,
+                    // which may differ from user input if Initializr sanitized the name.
+                    val effectivePackage = detectActualPackage(targetDir) ?: packageRoot
+                    TemplateGenerator.generate(targetDir, effectivePackage, arch)
 
                     indicator.text = "Syncing filesystem..."
                     val targetVFile = LocalFileSystem.getInstance().refreshAndFindFileByIoFile(targetDir)
@@ -131,6 +134,16 @@ class CreateNewProjectAction : AnAction("SpringForge: Create New Spring Boot Pro
                 }
             }
         }.queue()
+    }
+
+    private fun detectActualPackage(projectRoot: File): String? {
+        val srcMainJava = File(projectRoot, "src/main/java")
+        if (!srcMainJava.exists()) return null
+        val appFile = srcMainJava.walkTopDown()
+            .firstOrNull { it.isFile && it.name.endsWith("Application.java") }
+            ?: return null
+        val packageDir = appFile.parentFile ?: return null
+        return packageDir.relativeTo(srcMainJava).path.replace(File.separatorChar, '.')
     }
 
     private fun extractGroupId(pkg: String): String =

--- a/src/main/java/org/springforge/codegeneration/ui/CreateProjectDialog.kt
+++ b/src/main/java/org/springforge/codegeneration/ui/CreateProjectDialog.kt
@@ -13,12 +13,36 @@ import javax.swing.BorderFactory
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
 
 class CreateProjectDialog : DialogWrapper(true) {
+
+    companion object {
+        private val JAVA_KEYWORDS = setOf(
+            "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
+            "class", "const", "continue", "default", "do", "double", "else", "enum",
+            "extends", "final", "finally", "float", "for", "goto", "if", "implements",
+            "import", "instanceof", "int", "interface", "long", "native", "new",
+            "package", "private", "protected", "public", "return", "short", "static",
+            "strictfp", "super", "switch", "synchronized", "this", "throw", "throws",
+            "transient", "try", "void", "volatile", "while", "true", "false", "null"
+        )
+
+        fun isValidIdentifier(name: String): Boolean =
+            name.isNotEmpty() && name[0].isLetter() &&
+            name.all { it.isLetterOrDigit() || it == '_' || it == '-' } &&
+            name !in JAVA_KEYWORDS
+    }
 
     // Fields
     private val projectNameField = JBTextField("demo")
     private val packageRootField = JBTextField("com.example.demo")
+
+    // True when the package field is being updated programmatically (suppress re-entry)
+    private var syncingPackage = false
+    // True once the user has manually typed in the package field
+    private var packageManuallyEdited = false
 
     // Dropdowns
     private val archCombo = ComboBox(arrayOf("Layered", "MVC", "Clean"))
@@ -31,6 +55,34 @@ class CreateProjectDialog : DialogWrapper(true) {
 
     init {
         title = "Create New Spring Boot Project"
+
+        // Track manual edits to the package field (ignore programmatic updates)
+        packageRootField.document.addDocumentListener(object : DocumentListener {
+            override fun insertUpdate(e: DocumentEvent) { if (!syncingPackage) packageManuallyEdited = true }
+            override fun removeUpdate(e: DocumentEvent) { if (!syncingPackage) packageManuallyEdited = true }
+            override fun changedUpdate(e: DocumentEvent) { if (!syncingPackage) packageManuallyEdited = true }
+        })
+
+        // Auto-sync last package segment with project name
+        projectNameField.document.addDocumentListener(object : DocumentListener {
+            override fun insertUpdate(e: DocumentEvent) = syncPackage()
+            override fun removeUpdate(e: DocumentEvent) = syncPackage()
+            override fun changedUpdate(e: DocumentEvent) = syncPackage()
+
+            private fun syncPackage() {
+                if (packageManuallyEdited || syncingPackage) return
+                val name = projectNameField.text.trim().lowercase()
+                    .replace("[^a-z0-9]".toRegex(), "")
+                val base = packageRootField.text.substringBeforeLast(".", "com.example")
+                syncingPackage = true
+                try {
+                    packageRootField.text = if (name.isEmpty()) base else "$base.$name"
+                } finally {
+                    syncingPackage = false
+                }
+            }
+        })
+
         init()
     }
 
@@ -80,8 +132,18 @@ class CreateProjectDialog : DialogWrapper(true) {
     }
 
     override fun doValidate(): ValidationInfo? {
-        if (projectNameField.text.isBlank()) return ValidationInfo("Project name is required", projectNameField)
-        if (packageRootField.text.isBlank()) return ValidationInfo("Package is required", packageRootField)
+        val name = projectNameField.text.trim()
+        val pkg = packageRootField.text.trim()
+
+        if (name.isBlank()) return ValidationInfo("Project name is required", projectNameField)
+        if (name in JAVA_KEYWORDS)
+            return ValidationInfo("'$name' is a Java reserved keyword and cannot be used as a project name", projectNameField)
+
+        if (pkg.isBlank()) return ValidationInfo("Package is required", packageRootField)
+        val badSegment = pkg.split(".").firstOrNull { it in JAVA_KEYWORDS }
+        if (badSegment != null)
+            return ValidationInfo("'$badSegment' is a Java reserved keyword and cannot be used in a package name", packageRootField)
+
         return null
     }
 


### PR DESCRIPTION
This pull request improves the creation of new Spring Boot projects in the plugin by making package name selection more robust and user-friendly, and by adding better validation to prevent invalid project or package names. The main changes include detecting the actual package used by Spring Initializr, auto-syncing the package name with the project name, and validating against Java reserved keywords.

**Package detection and generation improvements:**
- The code now detects the actual package used by Spring Initializr (which may differ from user input if the name is sanitized) and uses that package when generating the architecture template (`CreateNewProjectAction.kt`).
- Added a helper method `detectActualPackage` to find the real package by locating the `Application.java` file and inferring the package path.

**UI/UX enhancements:**
- The package name field in the project creation dialog is now auto-synced with the project name, unless the user manually edits the package. This reduces errors and streamlines the workflow (`CreateProjectDialog.kt`).

**Validation improvements:**
- The dialog now prevents the use of Java reserved keywords as project names or as segments of the package name, providing clear error messages to the user. [[1]](diffhunk://#diff-bf04131ff74cead0375c81e0eb9171f1af970a0319498ac51bac4ef59e445f50R16-R46) [[2]](diffhunk://#diff-bf04131ff74cead0375c81e0eb9171f1af970a0319498ac51bac4ef59e445f50L83-R146)